### PR TITLE
Wrap if statement around split() method

### DIFF
--- a/host/bulk/bulk_update_hosts.rb
+++ b/host/bulk/bulk_update_hosts.rb
@@ -102,11 +102,14 @@ def properties_to_hash(properties)
   property_hash = {}
   index = 0
   properties_valid = properties || ''
-  props = properties.split(":")
-  props.each do |p|
-    eachProp = p.split("=")
-    property_hash[eachProp[0]] = eachProp[1]
-    index = index + 1
+  
+  if not properties.nil?
+    props = properties.split(":")
+    props.each do |p|
+      eachProp = p.split("=")
+      property_hash[eachProp[0]] = eachProp[1]
+      index = index + 1
+    end
   end
   return property_hash
 end


### PR DESCRIPTION
If the properties for a given row is empty, the variable will be nil and the properties.split(":") method should not be executed - doing so causes an error when using the script with a CSV with empty properties. There should be a check to ensure the properties variable is populated before executing, otherwise the properties_to_hash() method should just return empty property_hash.