### PR TITLE
Updates and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
     - ruby-1.9.3-p484
-script: "ruby -wc ."
+install:
+    - gem install rubocop
+script: 'rubocop'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
 rvm:
     - ruby-1.9.3-p484
-install:
-    - gem install ruby-lint
-script: "ruby-lint ."
+script: "ruby -wc ."

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is not a complete set of scripts required to fully manage your L
 
 ####Upcoming features
 - For bulk addition of hosts, the ability to create host groups to an arbitrary depth as part of the addition.
-- 
+-
 
 ####Platform specific tools
 The following scripts are for managing specific types of devices.
@@ -125,8 +125,8 @@ Usage: sdt_host.rb -c <company> -u <user> -p <password> -H <hostname> [-C <colle
     -D, --duration DURATION          How long this device should be in scheduled downtime. Format: 4d 6h 25
 ```
 
- 
-###mass-upload/bulk_add_hosts.rb 
+
+###mass-upload/bulk_add_hosts.rb
 This script parses a CSV formated list of hosts and adds them to monitoring.
 
 ```
@@ -136,14 +136,14 @@ Usage: ruby bulk_add_hosts.rb -c <company> -u <user> -p <password> -f <file>
     -c, --company COMPANY            LogicMonitor Account
     -u, --user USERNAME              LogicMonitor user name
     -p, --password PASSWORD          LogicMonitor password
-    -f, --file FILE                  A CSV file contaning the hosts to be added. 
+    -f, --file FILE                  A CSV file contaning the hosts to be added.
 ```
 
 We have provided a sample CSV file [example.csv](./host/bulk/example.csv) to show the required set and order of the columns. This script currently requires any host groups specified in the script to already exist in the account.
 To make sure that bulk_add_hosts can read the CSV file, you need to specify either the full path to the CSV file OR the relative path from the current working directory.
 
 ###mass-export/bulk_export_hosts.rb
-This scipt exports all of your hosts into a CSV file 
+This scipt exports all of your hosts into a CSV file
 
 ```
 $> ruby bulk_export_hosts.rb -h

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Usage: add_collector.rb -c <company> -u <user> -p <password> [-d]
     -c, --company COMPANY            LogicMonitor Account
     -u, --user USERNAME              LogicMonitor user name
     -p, --password PASSWORD          LogicMonitor password
+    -D, --description DESCRIPTION    Collector description
 ```
 ###collector/linux/remove_collector.rb
 This idempotent script removes and existing LogicMonitor collector from a Linux device. This script assumes that you are running the script on the machine that you want to remove a collector from. For more information about collector management [click here](http://help.logicmonitor.com/using/managing-collectors/).
@@ -52,6 +53,7 @@ Usage: add_collector.rb -c <company> -u <user> -p <password> [-d]
     -c, --company COMPANY            LogicMonitor Account
     -u, --user USERNAME              LogicMonitor user name
     -p, --password PASSWORD          LogicMonitor password
+    -D, --description DESCRIPTION    Collector description
 ```
 
 ###alerts/get_count_alerts.rb

--- a/alerts/get_count_alerts.rb
+++ b/alerts/get_count_alerts.rb
@@ -25,7 +25,7 @@ require 'optparse'
 def get_alerts()
   resp = rpc("getAlerts", {"level" => "warn"})
   alert_json = JSON.parse(resp)
-  if alert_json['data'] 
+  if alert_json['data']
     warns = 0
     error = 0
     crit = 0
@@ -51,7 +51,6 @@ def rpc(action, args={})
   username = @user
   password = @password
   url = "https://#{company}.logicmonitor.com/santaba/rpc/#{action}?"
-  first_arg = true
   args.each_pair do |key, value|
     url << "#{key}=#{value}&"
   end
@@ -67,6 +66,7 @@ def rpc(action, args={})
     return response.body
   rescue SocketError => se
     puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts se.message
   rescue Exception => e
     puts "There was an issue."
     puts e.message
@@ -108,28 +108,28 @@ begin
 rescue OptionParser::MissingArgument => ma
    puts ma.inspect
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1
@@ -142,4 +142,3 @@ end
 @collector = @options[:collector]
 
 get_alerts
-

--- a/collector/linux/add_collector.rb
+++ b/collector/linux/add_collector.rb
@@ -59,7 +59,7 @@ def run(name, install_dir)
     puts "Skipping installation."
   else
     install_collector(install_dir, file_name)
-  end 
+  end
   ensure_running()
 end
 
@@ -140,7 +140,6 @@ def download_install_file(action, args={})
   username = @user
   password = @password
   url = "https://#{company}.logicmonitor.com/santaba/do/#{action}?"
-  first_arg = true
   args.each_pair do |key, value|
     url << "#{key}=#{value}&"
   end
@@ -155,6 +154,7 @@ def download_install_file(action, args={})
     return response.body
   rescue SocketError => se
     puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts se.message
   rescue Error => e
     puts "There was an issue."
     puts e.message
@@ -167,7 +167,7 @@ def install_collector(install_dir, file_name)
   puts "Installing LogicMonitor collector"
   install_file = install_dir + file_name
   puts install_file
-  File.chmod(0755, install_file) 
+  File.chmod(0755, install_file)
   execution = `cd #{install_dir}; .#{file_name} -y`
   puts execution.to_s
 end
@@ -198,14 +198,13 @@ end
 
 
 # Wrapper function for building LogicMonitor API URL's
-# and executing the associated RPCs 
+# and executing the associated RPCs
 # returns a JSON string (the response from the LogicMonitor API) or nil
 def rpc(action, args={})
   company = @company
   username = @user
   password =  @password
   url = "https://#{company}.logicmonitor.com/santaba/rpc/#{action}?"
-  first_arg = true
   args.each_pair do |key, value|
     url << "#{key}=#{value}&"
   end
@@ -219,8 +218,8 @@ def rpc(action, args={})
     response = http.request(req)
     return response.body
   rescue SocketError => se
-    puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
-    puts "Exiting"
+    puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again. Exiting"
+    puts se.message
     exit 3
   rescue Error => e
     puts "There was an issue."
@@ -257,28 +256,28 @@ begin
 rescue OptionParser::MissingArgument => ma
    puts ma.inspect
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1

--- a/collector/linux/remove_collector.rb
+++ b/collector/linux/remove_collector.rb
@@ -42,7 +42,7 @@ def run(name, install_dir)
     puts "LogicMonitor Watchdog Stopped"
   end
 
-  collector = get_collector(name)  
+  collector = get_collector(name)
   if collector.nil?
     puts "unable to find collector matching #{name}"
   else
@@ -62,7 +62,7 @@ def run(name, install_dir)
   else
     puts "No matching collectors found"
   end
-  
+
 end
 
 
@@ -151,14 +151,13 @@ end
 
 
 # Wrapper function for building LogicMonitor API URL's
-# and executing the associated RPCs 
+# and executing the associated RPCs
 # returns a JSON string (the response from the LogicMonitor API) or nil
 def rpc(action, args={})
   company = @company
   username = @user
   password =  @password
   url = "https://#{company}.logicmonitor.com/santaba/rpc/#{action}?"
-  first_arg = true
   args.each_pair do |key, value|
     url << "#{key}=#{value}&"
   end
@@ -172,8 +171,8 @@ def rpc(action, args={})
     response = http.request(req)
     return response.body
   rescue SocketError => se
-    puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
-    puts "Exiting"
+    puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again. Exiting."
+    puts se.message
     exit 3
   rescue Error => e
     puts "There was an issue."
@@ -209,28 +208,28 @@ begin
 rescue OptionParser::MissingArgument => ma
    puts ma.inspect
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1

--- a/host/add_host.rb
+++ b/host/add_host.rb
@@ -243,7 +243,7 @@ def rpc(action, args={})
     response = http.request(req)
     return response.body
   rescue SocketError => se
-    puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts "There was an issue communicating with #{uri}. Please make sure everything is correct and try again."
     puts se.message
   rescue Exception => e
     puts "There was an issue."
@@ -304,8 +304,8 @@ begin
       @options[:properties] = props
     end
 
-    opts.on("-a", "--alertenable", "Turn on alerting for the host") do |p|
-      @options[:properties] = a
+    opts.on("-a", "--alertenable", "Turn on alerting for the host") do |a|
+      @options[:alertenable] = a
     end
 
   end.parse!

--- a/host/bulk/bulk_add_hosts.rb
+++ b/host/bulk/bulk_add_hosts.rb
@@ -35,7 +35,7 @@ def main
 
   groupname = "lmsupport-import-#{Time.now.strftime "%Y%m%d%H%M%S"}".chomp
   rpc("addHostGroup", {"alertEnable" => false, "name" => groupname})
- 
+
   string = rpc("getHostGroups") #makes API call to grab host group
   hostgroups= JSON.parse(string)
   my_arr=hostgroups['data']
@@ -46,7 +46,7 @@ def main
 
   lm_group_id = group_name_id_map[groupname]
   csv = CSV.new(filecontent, {:headers => true})
-  
+
   csv.each do |row|
     #Skip row in loop if the line is commented out (A.K.A. starts with a '#' character)
     next if row[0].start_with?('#')
@@ -69,28 +69,28 @@ def main
     else
       @display_name = row["display_name"]
     end
-    
-    # check for precense of a hostgroup and if there is, find the groupids 
+
+    # check for precense of a hostgroup and if there is, find the groupids
     group_list = build_group_list(row["group_list"], lm_group_id, group_name_id_map)
-    
+
     # check if properties are nil
 
     puts "Adding host #{@hostname} to LogicMonitor"
     puts "RPC Response:"
 
-    host_args = {"hostName" =>@hostname, 
-                 "displayedAs" =>@display_name, 
-                 "agentId" => @collector_id, 
-                 "hostGroupIds" => group_list.to_s, 
+    host_args = {"hostName" =>@hostname,
+                 "displayedAs" =>@display_name,
+                 "agentId" => @collector_id,
+                 "hostGroupIds" => group_list.to_s,
                  "description" => @description,
                  "link" => @link
                 }
-       
+
     host_args = host_args.merge(hash_to_lm(properties_to_hash(@properties)))
 
 
     puts rpc("addHost", host_args)
-    
+
   end
 end
 
@@ -137,6 +137,7 @@ def rpc(action, args={})
     return response.body
   rescue SocketError => se
     puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts se.message
   rescue Exception => e
     puts "There was an issue."
     puts e.message
@@ -235,7 +236,6 @@ end
 #                                                                 #
 ###################################################################
 
-pt_error = false
 begin
   @options = {}
   OptionParser.new do |opts|
@@ -260,40 +260,40 @@ begin
     opts.on("-f", "--file FILE", "A CSV file contaning the hosts to be added") do |f|
       @options[:file] = f
     end
-    
+
   end.parse!
 rescue OptionParser::MissingArgument => ma
   puts ma.inspect
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:file].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -f <file>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1

--- a/host/bulk/bulk_export_hosts.rb
+++ b/host/bulk/bulk_export_hosts.rb
@@ -61,8 +61,7 @@ end
 def rpc(action, args={})
   company = @company
   username = @user
-  password = @password 
-  test = URI(URI.encode password)
+  password = @password
   url = "https://#{company}.logicmonitor.com/santaba/rpc/#{action}?"
   args.each_pair do |key, value|
     url << "#{key}=#{value}&"
@@ -78,6 +77,7 @@ def rpc(action, args={})
     return response.body
   rescue SocketError => se
     puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts se.message
   rescue Exception => e
     puts "There was an issue."
     puts e.message
@@ -111,40 +111,40 @@ begin
     opts.on("-f", "--file FILE", "A CSV file contaning the hosts to be added") do |f|
       @options[:file] = f
     end
-    
+
   end.parse!
 rescue OptionParser::MissingArgument => ma
    puts ma.inspect
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:file].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -f <file>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1

--- a/host/remove_host.rb
+++ b/host/remove_host.rb
@@ -356,5 +356,6 @@ end
 
 #optional/default inputs
 @displayname = @options[:displayname] || @hostname
+@debug = @options[:debug]
 
 run(@hostname, @displayname, @collector)

--- a/host/remove_host.rb
+++ b/host/remove_host.rb
@@ -26,11 +26,14 @@ def run(hostname, displayname, collector)
   host_exist = get_host_by_displayname(displayname) || get_host_by_hostname(hostname, collector)
   if host_exist
     delete_resp = rpc("deleteHost", {"hostId" => host_exist["id"], "deleteFromSystem" => true})
+    if @debug
+        puts delete_resp
+    end
   else
     puts "Unable to find matching host"
     puts "Exiting"
     exit 1
-  end 
+  end
 end
 
 ###################################################################
@@ -57,12 +60,14 @@ def remove_host(hostname, displayname, collector, description, groups, propertie
   puts "d LogicMonitor host \"#{hostname}\""
   groups.each do |group|
     if get_group(group).nil?
-      puts "Couldn't find parent group #{group}. Creating." 
+      puts "Couldn't find parent group #{group}. Creating."
       recursive_group_create( group, nil, nil, true)
     end
   end
   add_resp = rpc("addHost", build_host_hash(hostname, displayname, collector, description, groups, properties, alertenable))
-  #puts add_resp
+  if @debug
+      puts add_resp
+  end
 end
 
 ###################################################################
@@ -214,13 +219,13 @@ end
 
 # return a group object if "fullpath" exists or nil
 def get_group(fullpath)
-  returnval = nil 
+  returnval = nil
   group_list = JSON.parse(rpc("getHostGroups", {}))
-  if group_list["data"].nil? 
+  if group_list["data"].nil?
     puts("Unable to retrieve list of host groups from LogicMonitor Account")
   else
     group_list["data"].each do |group|
-      if group["fullPath"].eql?(fullpath.sub("/", ""))    #Check to see if group exists          
+      if group["fullPath"].eql?(fullpath.sub("/", ""))    #Check to see if group exists
         returnval = group
       end
     end
@@ -233,7 +238,6 @@ def rpc(action, args={})
   username = @user
   password = @password
   url = "https://#{company}.logicmonitor.com/santaba/rpc/#{action}?"
-  first_arg = true
   args.each_pair do |key, value|
     url << "#{key}=#{value}&"
   end
@@ -249,6 +253,7 @@ def rpc(action, args={})
     return response.body
   rescue SocketError => se
     puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts se.message
   rescue Exception => e
     puts "There was an issue."
     puts e.message
@@ -287,11 +292,11 @@ begin
     opts.on("-C", "--collector COLLECTOR", "Collector to monitor this host") do |collector|
       @options[:collector] = collector
     end
-    
+
     opts.on("-H", "--name HOSTNAME", "Hostname of this device") do |hname|
       @options[:name] = hname
     end
-    
+
     opts.on("-n", "--displayname DISPLAYNAME", "The human readable name for the host in your LogicMonitor account") do |n|
       @options[:displayname] = n
     end
@@ -300,35 +305,35 @@ begin
 rescue OptionParser::MissingArgument => ma
    puts ma.inspect
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:collector].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -H <hostname>"
   opt_error = true
-end  
+end
 
 
 begin
@@ -336,7 +341,7 @@ begin
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -H <hostname>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1

--- a/host/sdt_host.rb
+++ b/host/sdt_host.rb
@@ -43,7 +43,7 @@ def run(hostname, displayname, collector, starttime, endtime)
     puts "Unable to find matching host"
     puts "Exiting"
     exit 1
-  end 
+  end
 end
 
 
@@ -57,7 +57,7 @@ end
 def to_time(timevar)
   offset = get_offset/3600
   zone = ActiveSupport::TimeZone[offset].name
-  Time.zone = zone 
+  Time.zone = zone
   if timevar.nil? or timevar.strip.empty?
      if Time.zone.now.isdst
        return Time.zone.now - (60 * 60)
@@ -99,7 +99,7 @@ def end_time(starttime, duration)
       else
         seconds = seconds + (60 * dur.to_i) #add seconds in the count of minutes
       end
-    end    
+    end
     return endtime + seconds
   else
     return endtime + (60*60) #default of 1 hour
@@ -178,7 +178,7 @@ def get_offset
     puts "Using GMT"
     return 0
   end
-  
+
 end
 
 
@@ -187,7 +187,6 @@ def rpc(action, args={})
   username = @user
   password = @password
   url = "https://#{company}.logicmonitor.com/santaba/rpc/#{action}?"
-  first_arg = true
   args.each_pair do |key, value|
     url << "#{key}=#{value}&"
   end
@@ -203,6 +202,7 @@ def rpc(action, args={})
     return response.body
   rescue SocketError => se
     puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts se.message
   rescue Exception => e
     puts "There was an issue."
     puts e.message
@@ -245,7 +245,7 @@ begin
     opts.on("-C", "--collector COLLECTOR", "The FQDN of the collector monitoring this device (required if -h is set)") do |col|
       @options[:displayname] = col
     end
-    
+
     opts.on("-n", "--displayname DISPLAYNAME", "The human readable name for the host in your LogicMonitor account") do |n|
       @options[:displayname] = n
     end
@@ -262,35 +262,35 @@ begin
 rescue OptionParser::MissingArgument => ma
    puts ma.inspect
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
    opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:name].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -H <hostname>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1
@@ -301,7 +301,7 @@ end
 @company = @options[:company]
 @user = @options[:user]
 @password = @options[:password]
-@hostname = @options[:name] 
+@hostname = @options[:name]
 
 #optional/default inputs
 @displayname = @options[:displayname] || @hostname

--- a/hostgroup/bulk/bulk_add_hostgroups.rb
+++ b/hostgroup/bulk/bulk_add_hostgroups.rb
@@ -56,8 +56,8 @@ def main
     @groupname = row["groupname"]
     @appliesTo = row["appliesTo"]
     @grouppath = row["grouppath"]
-    @description = row["description"] 
-    @properties = row["properties"] 
+    @description = row["description"]
+    @properties = row["properties"]
 
     #make sure that the group path entered follows Linux directory structure (for consistency and user ease-of-use)
     if not @grouppath.start_with?("/")
@@ -67,7 +67,7 @@ def main
     @grouppath.slice!(0)
 
     #makes API call to grab existing host groups
-    string = rpc("getHostGroups") 
+    string = rpc("getHostGroups")
     hostgroups= JSON.parse(string)
     my_arr=hostgroups['data']
 
@@ -87,20 +87,20 @@ def main
 
     #if appliesTo is not nil, assume group should be dynamic
     if @appliesTo.nil?
-      static_args = {"alertEnable" => false, 
-                   "name" => @groupname, 
-                   "parentId" =>  @parentid, 
+      static_args = {"alertEnable" => false,
+                   "name" => @groupname,
+                   "parentId" =>  @parentid,
                    "description" => @description
                   }
       static_args = static_args.merge(hash_to_lm(properties_to_hash(@properties)))
       puts rpc("addHostGroup", static_args)
     #if appliesTo is nil, assume group should be static
     else
-      dynamic_args = {"alertEnable" => false, 
-                    "dGroup" => true, 
-                    "name" => @groupname, 
-                    "appliesTo" => @appliesTo, 
-                    "parentId" => @parentid, 
+      dynamic_args = {"alertEnable" => false,
+                    "dGroup" => true,
+                    "name" => @groupname,
+                    "appliesTo" => @appliesTo,
+                    "parentId" => @parentid,
                     "description" => @description
                    }
       dynamic_args = dynamic_args.merge(hash_to_lm(properties_to_hash(@properties)))
@@ -159,7 +159,8 @@ def rpc(action, args={})
     response = http.request(req)
     return response.body
   rescue SocketError => se
-    puts "There was an issue communicating with #{url}. Please make sure everything is correct and try again."
+    puts "There was an issue communicating with #{uri}. Please make sure everything is correct and try again."
+    puts se.message
   rescue Exception => e
     puts "There was an issue."
     puts e.message
@@ -168,7 +169,7 @@ def rpc(action, args={})
 end
 
 #function to update the hash map after groups are created
-def group_id_map_update(fullpath, oldmap)
+def group_id_map_update(oldmap)
   string = rpc("getHostGroups") #makes API call to grab host group
   hostgroups= JSON.parse(string)
   my_arr=hostgroups['data']
@@ -192,7 +193,7 @@ def get_parentid(fullpath, map)
        parentid = map[parent_path].to_s
     else
       recursive_group_create(parent_path,false)
-      map = group_id_map_update(fullpath, map)
+      map = group_id_map_update(map)
       parentid = map[parent_path].to_s
     end
 
@@ -264,7 +265,6 @@ end
 #                                                                 #
 ###################################################################
 
-pt_error = false
 begin
   @options = {}
   OptionParser.new do |opts|
@@ -289,40 +289,40 @@ begin
     opts.on("-f", "--file FILE", "A CSV file contaning the hosts to be added") do |f|
       @options[:file] = f
     end
-    
+
   end.parse!
 rescue OptionParser::MissingArgument => ma
   puts ma.inspect
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:company].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -c <company>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:user].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -u <username>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:password].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -p <password>"
   opt_error = true
-end  
+end
 
 begin
   raise OptionParser::MissingArgument if @options[:file].nil?
 rescue  OptionParser::MissingArgument => ma
   puts "Missing option: -f <file>"
   opt_error = true
-end  
+end
 
 if opt_error
   exit 1


### PR DESCRIPTION
ruby-lint is throwing a lot of errors on non-error conditions like
using globally defined class includes such as Net::

There is absolutely nothing wrong with that and it’s certainly not an
error